### PR TITLE
Fix/session storage

### DIFF
--- a/src/jouwid.mjs
+++ b/src/jouwid.mjs
@@ -81,10 +81,10 @@ export async function login(options={})
 
     const forwardedToken = searchParams.get("token");
     if (forwardedToken) {
-        storage.set("id_token", forwardedToken, "local");
+        storage.set("id_token", forwardedToken);
     }
 
-    const storedToken = storage.get("id_token", "", "local");
+    const storedToken = storage.get("id_token", "");
     if (storedToken && storedToken !== idToken) {
         idToken = storedToken;
     }

--- a/src/jouwid.mjs
+++ b/src/jouwid.mjs
@@ -147,9 +147,14 @@ export async function logout(options)
 
     options = Object.assign({}, defaultOptions, options)
 
+    storage.remove("id_token");
+    storage.remove("jouwid-overlay-closed");
+    localStorage.removeItem(namespace + "id_token");
+    localStorage.removeItem(namespace + "jouwid-overlay-closed");
+    sessionStorage.removeItem(namespace + "id_token");
+    sessionStorage.removeItem(namespace + "jouwid-overlay-closed");
+
     if (remoteClient) {
-        storage.remove("id_token", "local");
-        storage.remove("id_token", "session");
         await remoteClient.getPassport().logout();
         if (options.logoutIDP) {
             // FIXME: do this through the remoteClient instead

--- a/src/jouwid.mjs
+++ b/src/jouwid.mjs
@@ -117,10 +117,10 @@ export async function login(options={})
  * Returns the current idToken, if the user is logged in. False otherwise.
  */
 export function isLoggedIn(options={}) {
-	const validOptions = {
-		keepLoggedIn: Optional(Boolean)
-	}
-	assert(options, validOptions)
+    const validOptions = {
+        keepLoggedIn: Optional(Boolean)
+    }
+    assert(options, validOptions)
 
     if (!storage) {
         storage = tokenStorage(options.keepLoggedIn ? 'local' : 'session');


### PR DESCRIPTION
Explicitly delete the id_token from localStorage and sessionStorage on logout. The storage layer keeps within local/session, the third argument is not used.